### PR TITLE
Fix typo: startup_stm32L4xx.s -> startup_stm32mp15xx.s

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Source/Templates/system_stm32mp1xx.c
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Source/Templates/system_stm32mp1xx.c
@@ -279,7 +279,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_raw/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_raw/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Demonstrations/AI_Character_Recognition/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Demonstrations/AI_Character_Recognition/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/CRC/CRC_UserDefinedPolynomial/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/CRC/CRC_UserDefinedPolynomial/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/CRYP/CRYP_AES_DMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/CRYP/CRYP_AES_DMA/Src/system_stm32mp1xx.c
@@ -264,7 +264,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/Cortex/CORTEXM_MPU/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/Cortex/CORTEXM_MPU/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/DMA/DMA_FIFOMode/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/DMA/DMA_FIFOMode/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/FDCAN/FDCAN_Loopback/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/FDCAN/FDCAN_Loopback/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/GPIO/GPIO_EXTI/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/GPIO/GPIO_EXTI/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/HASH/HASH_SHA224SHA256_DMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/HASH/HASH_SHA224SHA256_DMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/I2C/I2C_TwoBoards_ComIT/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/I2C/I2C_TwoBoards_ComIT/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/LPTIM/LPTIM_PulseCounter/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/LPTIM/LPTIM_PulseCounter/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Master/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Master/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Slave/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Slave/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/TIM/TIM_DMABurst/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/TIM/TIM_DMABurst/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComDMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComDMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComIT/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComIT/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Examples/WWDG/WWDG_Example/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Examples/WWDG/WWDG_Example/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-DK2/Templates/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-DK2/Templates/Src/system_stm32mp1xx.c
@@ -263,7 +263,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Applications/CoproSync/CoproSync_ShutDown/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Applications/CoproSync/CoproSync_ShutDown/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo/Src/system_stm32mp1xx.c
@@ -266,7 +266,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Src/system_stm32mp1xx.c
@@ -266,7 +266,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_raw/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_raw/Src/system_stm32mp1xx.c
@@ -266,7 +266,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Demonstrations/AI_Character_Recognition/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Demonstrations/AI_Character_Recognition/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/CRC/CRC_UserDefinedPolynomial/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/CRC/CRC_UserDefinedPolynomial/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/CRYP/CRYP_AES_DMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/CRYP/CRYP_AES_DMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/Cortex/CORTEXM_MPU/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/Cortex/CORTEXM_MPU/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/DAC/DAC_SimpleConversion/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/DAC/DAC_SimpleConversion/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/DMA/DMA_FIFOMode/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/DMA/DMA_FIFOMode/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/FDCAN/FDCAN_Loopback/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/FDCAN/FDCAN_Loopback/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/GPIO/GPIO_EXTI/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/GPIO/GPIO_EXTI/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/HASH/HASH_SHA224SHA256_DMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/HASH/HASH_SHA224SHA256_DMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComDMA/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComDMA/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComIT/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComIT/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/LPTIM/LPTIM_PulseCounter/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/LPTIM/LPTIM_PulseCounter/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/QSPI/QSPI_ReadWrite_IT/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/QSPI/QSPI_ReadWrite_IT/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/TIM/TIM_DMABurst/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/TIM/TIM_DMABurst/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/UART/UART_TwoBoards_ComIT/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/UART/UART_TwoBoards_ComIT/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Examples/WWDG/WWDG_Example/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Examples/WWDG/WWDG_Example/Src/system_stm32mp1xx.c
@@ -265,7 +265,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None

--- a/Projects/STM32MP157C-EV1/Templates/Src/system_stm32mp1xx.c
+++ b/Projects/STM32MP157C-EV1/Templates/Src/system_stm32mp1xx.c
@@ -263,7 +263,7 @@ void SystemCoreClockUpdate (void)
 #ifdef DATA_IN_ExtSRAM
 /**
   * @brief  Setup the external memory controller.
-  *         Called in startup_stm32L4xx.s before jump to main.
+  *         Called in startup_stm32mp15xx.s before jump to main.
   *         This function configures the external SRAM mounted on Eval boards
   *         This SRAM will be used as program data memory (including heap and stack).
   * @param  None


### PR DESCRIPTION
Hi,
I am not sure if this is a right place to report this, but I make the PR anyway.

I noticed a small typo while I was working on the library:
https://github.com/STMicroelectronics/STM32CubeMP1/blob/ce3cd02cb09aa23d5cb943abce3f2b588b702edf/Drivers/CMSIS/Device/ST/STM32MP1xx/Source/Templates/system_stm32mp1xx.c#L282
`startup_stm32L4xx.s` is clearly a typo. So I propose a PR to fix this.

Regards,
Bumsik Kim