### PR TITLE
Added missing termination braces for extern "C" definitions.

### DIFF
--- a/Drivers/BSP/STM32MP15xx_DISCO/stm32mp15xx_disco_conf_template.h
+++ b/Drivers/BSP/STM32MP15xx_DISCO/stm32mp15xx_disco_conf_template.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Drivers/BSP/STM32MP15xx_DISCO/stm32mp15xx_disco_errno.h
+++ b/Drivers/BSP/STM32MP15xx_DISCO/stm32mp15xx_disco_errno.h
@@ -35,12 +35,16 @@
 #define BSP_ERROR_PERIPH_FAILURE         -4
 #define BSP_ERROR_COMPONENT_FAILURE      -5
 #define BSP_ERROR_UNKNOWN_FAILURE        -6
-#define BSP_ERROR_UNKNOWN_COMPONENT      -7 
-#define BSP_ERROR_BUS_FAILURE            -8 
-#define BSP_ERROR_CLOCK_FAILURE          -9  
-#define BSP_ERROR_MSP_FAILURE            -10  
+#define BSP_ERROR_UNKNOWN_COMPONENT      -7
+#define BSP_ERROR_BUS_FAILURE            -8
+#define BSP_ERROR_CLOCK_FAILURE          -9
+#define BSP_ERROR_MSP_FAILURE            -10
 #define BSP_ERROR_FEATURE_NOT_SUPPORTED  -11
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* STM32MP15XX_DISCO_ERRNO_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Drivers/BSP/STM32MP15xx_EVAL/stm32mp15xx_eval_conf_template.h
+++ b/Drivers/BSP/STM32MP15xx_EVAL/stm32mp15xx_eval_conf_template.h
@@ -55,7 +55,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Applications/CoproSync/CoproSync_ShutDown/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Applications/CoproSync/CoproSync_ShutDown/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_FreeRTOS_echo/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_FreeRTOS_echo/Inc/stm32mp15xx_disco_conf.h
@@ -55,6 +55,10 @@ extern "C" {
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_raw/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_raw/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/CRC/CRC_UserDefinedPolynomial/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/CRC/CRC_UserDefinedPolynomial/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/CRYP/CRYP_AES_DMA/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/CRYP/CRYP_AES_DMA/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/Cortex/CORTEXM_MPU/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/Cortex/CORTEXM_MPU/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/DMA/DMA_FIFOMode/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/DMA/DMA_FIFOMode/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/FDCAN/FDCAN_Loopback/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/FDCAN/FDCAN_Loopback/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/GPIO/GPIO_EXTI/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/GPIO/GPIO_EXTI/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/HASH/HASH_SHA224SHA256_DMA/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/HASH/HASH_SHA224SHA256_DMA/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/I2C/I2C_TwoBoards_ComIT/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/I2C/I2C_TwoBoards_ComIT/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/LPTIM/LPTIM_PulseCounter/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/LPTIM/LPTIM_PulseCounter/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/PWR/PWR_STOP_CoPro/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/PWR/PWR_STOP_CoPro/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Master/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Master/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Slave/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/SPI/SPI_FullDuplex_ComIT_Slave/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/TIM/TIM_DMABurst/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/TIM/TIM_DMABurst/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/UART/UART_Receive_Transmit_Console/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/UART/UART_Receive_Transmit_Console/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComDMA/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComDMA/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComIT/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/UART/UART_TwoBoards_ComIT/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Examples/WWDG/WWDG_Example/Inc/stm32mp15xx_disco_conf.h
+++ b/Projects/STM32MP157C-DK2/Examples/WWDG/WWDG_Example/Inc/stm32mp15xx_disco_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_DISCO_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-DK2/Templates/Inc/lock_resource.h
+++ b/Projects/STM32MP157C-DK2/Templates/Inc/lock_resource.h
@@ -20,6 +20,10 @@
 #ifndef __LOCK_RESOURCE_H__
 #define __LOCK_RESOURCE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Includes ------------------------------------------------------------------*/
 #include "stm32mp1xx_hal.h"
 
@@ -43,7 +47,9 @@ typedef enum
 LockResource_Status_t Periph_Lock(void* Peripheral, uint32_t Timeout);
 void Periph_Unlock(void* Peripheral);
 
-
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* __LOCK_RESOURCE_H__ */

--- a/Projects/STM32MP157C-EV1/Applications/CoproSync/CoproSync_ShutDown/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/CoproSync/CoproSync_ShutDown/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/FreeRTOS/FreeRTOS_ThreadCreation/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_Dynamic_ResMgr/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_Dynamic_ResMgr/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_FreeRTOS_echo/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_FreeRTOS_echo/Inc/stm32mp15xx_eval_conf.h
@@ -55,6 +55,10 @@ extern "C" {
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_raw/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Applications/OpenAMP/OpenAMP_raw/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/ADC/ADC_SingleConversion_TriggerTimer_DMA/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/CRC/CRC_UserDefinedPolynomial/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/CRC/CRC_UserDefinedPolynomial/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/CRYP/CRYP_AES_DMA/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/CRYP/CRYP_AES_DMA/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/Cortex/CORTEXM_MPU/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/Cortex/CORTEXM_MPU/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/DAC/DAC_SimpleConversion/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/DAC/DAC_SimpleConversion/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/DMA/DMA_FIFOMode/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/DMA/DMA_FIFOMode/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/FDCAN/FDCAN_Loopback/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/FDCAN/FDCAN_Loopback/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/GPIO/GPIO_EXTI/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/GPIO/GPIO_EXTI/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/HASH/HASH_SHA224SHA256_DMA/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/HASH/HASH_SHA224SHA256_DMA/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComDMA/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComDMA/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComIT/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/I2C/I2C_TwoBoards_ComIT/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/LPTIM/LPTIM_PulseCounter/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/LPTIM/LPTIM_PulseCounter/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/PWR/PWR_STOP_CoPro/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/PWR/PWR_STOP_CoPro/Inc/stm32mp15xx_eval_conf.h
@@ -55,7 +55,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/QSPI/QSPI_ReadWrite_IT/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/QSPI/QSPI_ReadWrite_IT/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Master/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/SPI/SPI_FullDuplex_ComDMA_Slave/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/TIM/TIM_DMABurst/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/TIM/TIM_DMABurst/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/UART/UART_Receive_Transmit_Console/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/UART/UART_Receive_Transmit_Console/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/UART/UART_TwoBoards_ComIT/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/UART/UART_TwoBoards_ComIT/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Examples/WWDG/WWDG_Example/Inc/stm32mp15xx_eval_conf.h
+++ b/Projects/STM32MP157C-EV1/Examples/WWDG/WWDG_Example/Inc/stm32mp15xx_eval_conf.h
@@ -54,7 +54,11 @@
 #define BSP_BUTTON_WAKEUP_IT_PRIORITY          0x0FUL
 #define BSP_BUTTON_USER_IT_PRIORITY            0x0FUL
 #define BSP_BUTTON_USER2_IT_PRIORITY           0x0FUL
-   
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* __STM32MP15XX_EVAL_CONFIG_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Projects/STM32MP157C-EV1/Templates/Inc/lock_resource.h
+++ b/Projects/STM32MP157C-EV1/Templates/Inc/lock_resource.h
@@ -20,6 +20,10 @@
 #ifndef __LOCK_RESOURCE_H__
 #define __LOCK_RESOURCE_H__
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Includes ------------------------------------------------------------------*/
 #include "stm32mp1xx_hal.h"
 
@@ -43,7 +47,9 @@ typedef enum
 LockResource_Status_t Periph_Lock(void* Peripheral, uint32_t Timeout);
 void Periph_Unlock(void* Peripheral);
 
-
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* __LOCK_RESOURCE_H__ */


### PR DESCRIPTION
When compiling C++ based firmware, many things break as there are unterminated extern "C" definitions when the file stm32mp15xx_disco.h is included. Also, unterminated  extern "C"  definitions exist in the stm32mp15xx_disco_conf.h and stm32mp15xx_eval_conf.h in all the example projects and applications.

This pull request aims at fixing those so that STM32CubeMx1 can be used with M4 codebases using C++. Please feel free to edit/remove/reorder as you deem fit.