### PR TITLE
CMSIS Compliance: updated physical timer interrupt names

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151axx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151axx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151cxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151cxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151dxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151dxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151fxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp151fxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153axx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153axx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153cxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153cxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153dxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153dxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153fxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp153fxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157axx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157axx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157cxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157cxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157dxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157dxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */

--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157fxx_ca7.h
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Include/stm32mp157fxx_ca7.h
@@ -80,8 +80,8 @@
    HypervisorTimer_IRQn             = 26,     /*!< Hypervisor Timer Interrupt                                           */
    VirtualTimer_IRQn                = 27,     /*!< Virtual Timer Interrupt                                              */
    Legacy_nFIQ_IRQn                 = 28,     /*!< Legacy nFIQ Interrupt                                                */
-   SecurePhysicalTimer_IRQn         = 29,     /*!< Secure Physical Timer Interrupt                                      */
-   NonSecurePhysicalTimer_IRQn      = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
+   SecurePhyTimer_IRQn              = 29,     /*!< Secure Physical Timer Interrupt                                      */
+   NonSecurePhyTimer_IRQn           = 30,     /*!< Non-Secure Physical Timer Interrupt                                  */
    Legacy_nIRQ_IRQn                 = 31,     /*!< Legacy nIRQ Interrupt                                                */
    /******  STM32 specific Interrupt Numbers ****************************************************************************/    
    WWDG1_IRQn                       = 32,     /*!< Window WatchDog Interrupt                                            */


### PR DESCRIPTION
For CMSIS Compliance I would like to suggest updating Cortex-A physical timer interrupt names in device header files for coherence with CMSIS OS Tick implementation for Generic Timer:
https://github.com/ARM-software/CMSIS_5/blob/develop/CMSIS/RTOS2/Source/os_tick_gtim.c