### PR TITLE
VIRT_UART_Transmit should take const void* pData

### DIFF
--- a/Middlewares/Third_Party/OpenAMP/virtual_driver/virt_uart.c
+++ b/Middlewares/Third_Party/OpenAMP/virtual_driver/virt_uart.c
@@ -110,7 +110,7 @@ VIRT_UART_StatusTypeDef VIRT_UART_RegisterCallback(VIRT_UART_HandleTypeDef *huar
   return status;
 }
 
-VIRT_UART_StatusTypeDef VIRT_UART_Transmit(VIRT_UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size)
+VIRT_UART_StatusTypeDef VIRT_UART_Transmit(VIRT_UART_HandleTypeDef *huart, const void *pData, uint16_t Size)
 {
 	int res;
 

--- a/Middlewares/Third_Party/OpenAMP/virtual_driver/virt_uart.h
+++ b/Middlewares/Third_Party/OpenAMP/virtual_driver/virt_uart.h
@@ -64,7 +64,7 @@ VIRT_UART_StatusTypeDef VIRT_UART_RegisterCallback(VIRT_UART_HandleTypeDef *huar
                                                    void (* pCallback)(VIRT_UART_HandleTypeDef *_huart));
 
 /* IO operation functions *****************************************************/
-VIRT_UART_StatusTypeDef VIRT_UART_Transmit(VIRT_UART_HandleTypeDef *huart, uint8_t *pData, uint16_t Size);
+VIRT_UART_StatusTypeDef VIRT_UART_Transmit(VIRT_UART_HandleTypeDef *huart, const void *pData, uint16_t Size);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
The typing of the `pData` argument to `VIRT_UART_Transmit` should match the type of the data argument to `OPENAMP_send` aka `rpmsg_send`, which is `const void*` (not `uint8_t*`). This will allow users to send arbitrary data, including constant data like string literals and data in the form of a struct pointer, without needing to cast the data to a `uint8_t*` first. Additionally, this may allow the compiler to further optimize the `VIRT_UART_Transmit` function.