### PR TITLE
Fixed an error. The stm32mp1xx have 16 byte FIFO in USART.

### DIFF
--- a/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_usart_ex.c
+++ b/Drivers/STM32MP1xx_HAL_Driver/Src/stm32mp1xx_hal_usart_ex.c
@@ -58,10 +58,10 @@
   * @{
   */
 /* USART RX FIFO depth */
-#define RX_FIFO_DEPTH 8U
+#define RX_FIFO_DEPTH 16U
 
 /* USART TX FIFO depth */
-#define TX_FIFO_DEPTH 8U
+#define TX_FIFO_DEPTH 16U
 /**
   * @}
   */


### PR DESCRIPTION
See the Table 365. USART features in the RM0436 Rev 2 at the page 2605.

I checked the fixed code. It works fine.

![image](https://user-images.githubusercontent.com/31692499/146941329-49dffb01-6965-4066-bb40-b738430791ea.png)
