### PR TITLE
Increasing the number of shared memory regions. 

### DIFF
--- a/Middlewares/Third_Party/OpenAMP/libmetal/lib/include/metal/system/generic/sys.h
+++ b/Middlewares/Third_Party/OpenAMP/libmetal/lib/include/metal/system/generic/sys.h
@@ -30,7 +30,7 @@ extern "C" {
 #endif
 
 #ifndef METAL_MAX_DEVICE_REGIONS
-#define METAL_MAX_DEVICE_REGIONS 1
+#define METAL_MAX_DEVICE_REGIONS 2
 #endif
 
 /** Structure of generic libmetal runtime state. */


### PR DESCRIPTION
The function OPENAMP_shmem_init from the OpenAMP examples uses 2 regions. See Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo_wakeup/Src/openamp.c