### PR TITLE
Change include in system_stm32mp1xx.c

### DIFF
--- a/Drivers/CMSIS/Device/ST/STM32MP1xx/Source/Templates/system_stm32mp1xx.c
+++ b/Drivers/CMSIS/Device/ST/STM32MP1xx/Source/Templates/system_stm32mp1xx.c
@@ -45,7 +45,7 @@
   * @{
   */
 
-#include "stm32mp1xx_hal.h"
+#include "stm32mp1xx.h"
 
 /**
   * @}


### PR DESCRIPTION
CMSIS shall not depend on HAL except when USE_HAL_DRIVER is defined.
This is the way it is managed in all other families. I suppose it shall be the same here.