### PR TITLE
ll_tim: correct centeraligned countermode defines

### DIFF
--- a/Drivers/STM32MP1xx_HAL_Driver/Inc/stm32mp1xx_ll_tim.h
+++ b/Drivers/STM32MP1xx_HAL_Driver/Inc/stm32mp1xx_ll_tim.h
@@ -609,10 +609,10 @@ typedef struct
 /** @defgroup TIM_LL_EC_COUNTERMODE Counter Mode
   * @{
   */
-#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!<Counter used as upcounter */
+#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!< Counter used as upcounter */
 #define LL_TIM_COUNTERMODE_DOWN                TIM_CR1_DIR          /*!< Counter used as downcounter */
-#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
-#define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_1        /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
+#define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
+#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_1        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up. */
 #define LL_TIM_COUNTERMODE_CENTER_UP_DOWN      TIM_CR1_CMS          /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up or down. */
 /**
   * @}


### PR DESCRIPTION
Currently, the `LL_TIM_COUNTERMODE_CENTER_DOWN` and `LL_TIM_COUNTERMODE_CENTER_UP`
don't comply with the reference manual and HAL defines.

- `LL_TIM_COUNTERMODE_CENTER_DOWN` is `Center-aligned mode 1` and shall be qual to `TIM_CR1_CMS_0`
- `LL_TIM_COUNTERMODE_CENTER_UP` is `Center-aligned mode 2` and shall be equal to `TIM_CR1_CMS_1`