### PR TITLE
OpenAMP semaphore init before first use

### DIFF
--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo/Src/main.c
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_TTY_echo/Src/main.c
@@ -97,12 +97,13 @@ int main(void)
                                             ((HAL_GetHalVersion() >> 24) & 0x000000FF),
                                             ((HAL_GetHalVersion() >> 16) & 0x000000FF),
                                             ((HAL_GetHalVersion() >> 8) & 0x000000FF));
+  /*HW semaphore Clock enable*/
+  __HAL_RCC_HSEM_CLK_ENABLE();
+  
   BSP_LED_Init(LED7);
   BSP_LED_On(LED7);
   /* USER CODE END Init */
 
-  /*HW semaphore Clock enable*/
-  __HAL_RCC_HSEM_CLK_ENABLE();
   /* IPCC initialisation */
    MX_IPCC_Init();
   /* OpenAmp initialisation ---------------------------------*/

--- a/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_for_signed_fw/Src/main.c
+++ b/Projects/STM32MP157C-DK2/Applications/OpenAMP/OpenAMP_for_signed_fw/Src/main.c
@@ -97,12 +97,13 @@ int main(void)
                                             ((HAL_GetHalVersion() >> 24) & 0x000000FF),
                                             ((HAL_GetHalVersion() >> 16) & 0x000000FF),
                                             ((HAL_GetHalVersion() >> 8) & 0x000000FF));
+  /*HW semaphore Clock enable*/
+  __HAL_RCC_HSEM_CLK_ENABLE();
+  
   BSP_LED_Init(LED7);
   BSP_LED_On(LED7);
   /* USER CODE END Init */
 
-  /*HW semaphore Clock enable*/
-  __HAL_RCC_HSEM_CLK_ENABLE();
   /* IPCC initialisation */
    MX_IPCC_Init();
   /* OpenAmp initialisation ---------------------------------*/


### PR DESCRIPTION
HSEM clock was enabled after first use, resulting in endless loop without error exception. Moved HSEM clock enable before first use.

`BSP_LED_Init()` function uses `BSP_ENTER_CRITICAL_SECTION()` function. If you follow inside the function, `HAL_HSEM_FastTake()` is being called which reads HSEM_RLR register. Register reading was done before HSEM clock was enabled.